### PR TITLE
Multi-Scorers

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -45,7 +45,7 @@ USAGE
      perl scorer.pl <metric> <key> <response> [<document-id>]
 
 
-     <metric>: the metric desired to score the results. one of the following values:
+     <metric>: the metrics desired to score the results (separated by +). ones of the following values:
 
      muc: MUCScorer (Vilain et al, 1995)
      bcub: B-Cubed (Bagga and Baldwin, 1998)
@@ -57,7 +57,7 @@ USAGE
      <key>: file with expected coreference chains in CoNLL-2011/2012 format
 
      <response>: file with output of coreference system (CoNLL-2011/2012 format)
- 
+
      <document-id>: optional. The name of the document to score. If name is not
                     given, all the documents in the dataset will be scored. If given
                     name is "none" then all the documents are scored but only total

--- a/lib/CorScorer.pm
+++ b/lib/CorScorer.pm
@@ -68,7 +68,7 @@ print "version: " . $VERSION . " " . Cwd::realpath(__FILE__) . "\n";
 # 1.02 Corrected BCUB bug. It fails when the key file does not have any mention
 
 # global variables
-my $VERBOSE         = 2;
+my $VERBOSE         = 1;
 my $HEAD_COLUMN     = 8;
 my $RESPONSE_COLUMN = -1;
 my $KEY_COLUMN      = -1;
@@ -369,7 +369,7 @@ sub IdentifMentions {
 
     my $i = 0;
     my @remove;
-		
+
     foreach my $mention (@$entity) {
       if (defined($map{"$mention->[0],$mention->[1]"})) {
         print "Repeated mention in the response: $mention->[0], $mention->[1] ",

--- a/scorer.pl
+++ b/scorer.pl
@@ -19,7 +19,7 @@ if (@ARGV < 3) {
   print q|
 use: scorer.pl <metric> <keys_file> <response_file> [name]
 
-  metric: the metric desired to score the results:
+  metric: the metrics desired to score the results (separated by +):
     muc: MUCScorer (Vilain et al, 1995)
     bcub: B-Cubed (Bagga and Baldwin, 1998)
     ceafm: CEAF (Luo et al, 2005) using mention-based similarity
@@ -41,9 +41,11 @@ use: scorer.pl <metric> <keys_file> <response_file> [name]
 }
 
 my $metric = shift(@ARGV);
-if ($metric !~ /^(muc|bcub|ceafm|ceafe|blanc|all)/i) {
-  print "Invalid metric\n";
-  exit;
+foreach my $m (split(/\+/,$metric)){
+  if ($m !~ /^(muc|bcub|ceafm|ceafe|blanc|all)/i) {
+    print "Invalid metric: ".$m."\n";
+    exit;
+  }
 }
 
 if ($metric eq 'all') {
@@ -53,6 +55,8 @@ if ($metric eq 'all') {
   }
 }
 else {
-  &CorScorer::Score($metric, @ARGV);
+  foreach my $m (split(/\+/,$metric)){
+    print "\nMETRIC $m:\n";
+    &CorScorer::Score($m, @ARGV);
+  }
 }
-

--- a/scorer.pl
+++ b/scorer.pl
@@ -48,7 +48,7 @@ foreach my $m (split(/\+/,$metric)){
   }
 }
 
-if ($metric eq 'all') {
+if ( grep( /^all&/, split(/\+/,$metric)) ) {
   foreach my $m ('muc', 'bcub', 'ceafm', 'ceafe', 'blanc') {
     print "\nMETRIC $m:\n";
     &CorScorer::Score($m, @ARGV);


### PR DESCRIPTION
Current implementation of scorer.pl only allow one or all scorers to be computed.
This MR contains changes allowing user to chose which scorers to compute in only one command.
e.g. `$ perl scorer.pl muc+bcub <keys_file> <response_file> [name] `

No changes were done on scorer.bat because I don't work on Windows and can't check it works.